### PR TITLE
Conform to ROOT standard for boolean code

### DIFF
--- a/Common/src/TreeTypeNamesTS.cc
+++ b/Common/src/TreeTypeNamesTS.cc
@@ -83,7 +83,7 @@ std::string TreeTypeNames::typeName( unsigned short*  dataPtr ) {
 
 template <>
 std::string TreeTypeNames::typeCode( bool*  dataPtr ) {
-  return "A";
+  return "O";
 }
 template <>
 std::string TreeTypeNames::typeName( bool*  dataPtr ) {
@@ -93,7 +93,7 @@ std::string TreeTypeNames::typeName( bool*  dataPtr ) {
 
 template <>
 std::string TreeTypeNames::typeCode( bool**  dataPtr ) {
-  return "A";
+  return "O";
 }
 template <>
 std::string TreeTypeNames::typeName( bool**  dataPtr ) {


### PR DESCRIPTION
Ciao Paolo,

the string "A" for booleans is not standard  in ROOT, which uses "O". I get errors creating a root tree with booleans unless I change it to the ROOT default.